### PR TITLE
Removed unnecessary content from AndroidManifest.xml

### DIFF
--- a/searchview/src/main/AndroidManifest.xml
+++ b/searchview/src/main/AndroidManifest.xml
@@ -1,9 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.lapism.searchview">
+<manifest package="com.lapism.searchview">
 
-    <application
-        android:allowBackup="true"
-        android:fullBackupContent="true"
-        android:supportsRtl="true" />
+    <application/>
 
 </manifest>


### PR DESCRIPTION
This avoids possible manifest merging errors when building an app with this library.