### PR TITLE
#72 - Add style attributes to define whether search view should be cleaned upon open/close

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,6 @@ dependencies {
         <attr name="search_shadow" format="boolean" />
         <attr name="search_shadow_color" format="boolean" />
         <attr name="search_elevation" format="dimension" />
+        <attr name="search_clear_on_close" format="boolean" />
+        <attr name="search_clear_on_open" format="boolean" />
 ```

--- a/sample/src/main/res/layout/activity_toggle.xml
+++ b/sample/src/main/res/layout/activity_toggle.xml
@@ -34,10 +34,6 @@
 
         </android.support.design.widget.AppBarLayout>
 
-        <!-- "?attr/actionBarSize"
-?attr/actionBarSize@CoordinatorLayout.DefaultBehavior(FloatingActionButton.Behavior.class)
-        android.support.v4.widget.NestedScrollView -->
-
         <android.support.v4.view.ViewPager
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
@@ -58,7 +54,9 @@
     <com.lapism.searchview.SearchView
         android:id="@+id/searchView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:search_clear_on_close="false"
+        app:search_clear_on_open="false"/>
 
     <android.support.design.widget.NavigationView
         android:id="@+id/nav_view"

--- a/searchview/src/main/java/com/lapism/searchview/SearchView.java
+++ b/searchview/src/main/java/com/lapism/searchview/SearchView.java
@@ -93,6 +93,8 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
     private boolean mShadow = true;
     private boolean mVoice = true;
     private boolean mIsSearchOpen = false;
+    private boolean mShouldClearOnClose;
+    private boolean mShouldClearOnOpen;
 
     private SavedState mSavedState;
     private CharSequence mOldQueryText;
@@ -341,6 +343,9 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
                 setElevation(attr.getDimensionPixelSize(R.styleable.SearchView_search_elevation, 0));
             }
 
+            mShouldClearOnClose = attr.getBoolean(R.styleable.SearchView_search_clear_on_close, true);
+            mShouldClearOnOpen = attr.getBoolean(R.styleable.SearchView_search_clear_on_open, true);
+
             attr.recycle();
         }
     }
@@ -564,7 +569,7 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
                 }
             } else {
                 mCardView.setVisibility(View.VISIBLE);
-                if (mEditText.length() > 0) {
+                if (mShouldClearOnOpen && mEditText.length() > 0) {
                     mEditText.getText().clear();
                 }
                 mEditText.requestFocus();
@@ -574,7 +579,7 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
             }
         }
         if (mVersion == VERSION_TOOLBAR) {
-            if (mEditText.length() > 0) {
+            if (mShouldClearOnOpen && mEditText.length() > 0) {
                 mEditText.getText().clear();
             }
             mEditText.requestFocus();
@@ -594,7 +599,7 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
                     SearchAnimator.fadeClose(mCardView, mAnimationDuration, mEditText, this, mOnOpenCloseListener);
                 }
             } else {
-                if (mEditText.length() > 0) {
+                if (mShouldClearOnClose && mEditText.length() > 0) {
                     mEditText.getText().clear();
                 }
                 mEditText.clearFocus();
@@ -606,7 +611,7 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
             }
         }
         if (mVersion == VERSION_TOOLBAR) {
-            if (mEditText.length() > 0) {
+            if (mShouldClearOnClose && mEditText.length() > 0) {
                 mEditText.getText().clear();
             }
             mEditText.clearFocus();

--- a/searchview/src/main/res/values/attrs.xml
+++ b/searchview/src/main/res/values/attrs.xml
@@ -38,6 +38,8 @@
         <attr name="search_shadow" format="boolean" />
         <attr name="search_shadow_color" format="boolean" />
         <attr name="search_elevation" format="dimension" />
+        <attr name="search_clear_on_close" format="boolean" />
+        <attr name="search_clear_on_open" format="boolean" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
**This fixes #72** 

Add two style attributes to define whether search view should be cleaned upon open/close:

```
        <attr name="search_clear_on_close" format="boolean" />
        <attr name="search_clear_on_open" format="boolean" />
```

By default, the values of these attributes are set to **true**, so users that update to the new library version aren't surprised with the new behavior. Thus, users that want to keep the values upon close/open, should explicitly set either or both these new attributes to **false**.

I've updated the README with these new attributes as well.