### PR TITLE
https://github.com/lapism/SearchView/issues/143

### DIFF
--- a/searchview/src/main/java/com/lapism/searchview/SearchEditText.java
+++ b/searchview/src/main/java/com/lapism/searchview/SearchEditText.java
@@ -28,10 +28,12 @@ public class SearchEditText extends AppCompatEditText {
 
     @Override
     public boolean onKeyPreIme(int keyCode, KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
-            if (mSearchView != null && mSearchView.isSearchOpen()) {
-                mSearchView.close(true);
-                return true;
+        if (mSearchView.getShouldHideOnKeyboardClose() ) {
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
+                if (mSearchView != null && mSearchView.isSearchOpen()) {
+                    mSearchView.close(true);
+                    return true;
+                }
             }
         }
         // return super.onKeyPreIme(keyCode, event);

--- a/searchview/src/main/java/com/lapism/searchview/SearchView.java
+++ b/searchview/src/main/java/com/lapism/searchview/SearchView.java
@@ -97,6 +97,7 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
 
     private boolean mShouldClearOnClose = true;
     private boolean mShouldClearOnOpen = true;
+    private boolean mShouldHideOnKeyboardClose = true;
 
     // ---------------------------------------------------------------------------------------------
     public SearchView(Context context) {
@@ -340,7 +341,9 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
             if (attr.hasValue(R.styleable.SearchView_search_clear_on_open)) {
                 setShouldClearOnOpen(attr.getBoolean(R.styleable.SearchView_search_clear_on_open, true));
             }
-
+            if (attr.hasValue(R.styleable.SearchView_search_hide_on_keyboard_close)){
+                setShouldHideOnKeyboardClose(attr.getBoolean(R.styleable.SearchView_search_hide_on_keyboard_close,true));
+            }
             attr.recycle();
         }
     }
@@ -546,6 +549,18 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
 
     public void setShouldClearOnOpen(boolean shouldClearOnOpen) {
         mShouldClearOnOpen = shouldClearOnOpen;
+    }
+
+    public boolean getShouldHideOnKeyboardClose() {
+        return mShouldHideOnKeyboardClose;
+    }
+
+    /**
+     *
+     * @param shouldHideOnKeyboardClose to auto hide the searchview when keyboard is close
+     */
+    public void setShouldHideOnKeyboardClose(boolean shouldHideOnKeyboardClose){
+        mShouldHideOnKeyboardClose = shouldHideOnKeyboardClose;
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/searchview/src/main/res/values/attrs.xml
+++ b/searchview/src/main/res/values/attrs.xml
@@ -40,6 +40,8 @@
         <attr name="search_elevation" format="dimension" />
         <attr name="search_clear_on_close" format="boolean" />
         <attr name="search_clear_on_open" format="boolean" />
+        <attr name="search_hide_on_keyboard_close" format="boolean" />
+
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Hi,

Firstly, thanks for your lib, it is very usefull and easy to integrate.

I would have a request for you. For now I use this view as a menu item, and I go to a fragment search to do my research while showing the searchview . I works well but when I want to hide the keyboard to see all result, the search view close because it goes into this :

SearchEditText.java

```java
 @Override
    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
        if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
            if (mSearchView != null && mSearchView.isSearchOpen()) {
                mSearchView.close(true);
                return true;
            }
        }
        // return super.onKeyPreIme(keyCode, event);
        return super.dispatchKeyEvent(event);
    }

```

I was thinking of adding a new attribute to the material searchview, 

        <com.lapism.searchview.SearchView
            android:id="@+id/search_view"
            android:layout_width="match_parent"
            android:layout_height="match_parent"
            app:search_divider="true"
            app:hide_on_keyboard_close="true" />


In this case in SearchEditText : 


```java
 @Override
    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
       if( mSearchView.shouldHideOnKeyboardClose())  {
        if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
            if (mSearchView != null && mSearchView.isSearchOpen()) {
                mSearchView.close(true);
                return true;
            }
        }
       }
        // return super.onKeyPreIme(keyCode, event);
        return super.dispatchKeyEvent(event);
    }

```


I 'll do a PR for all that