### PR TITLE
Added tag field to SearchItem

### DIFF
--- a/searchview/src/main/java/com/lapism/searchview/SearchAdapter.java
+++ b/searchview/src/main/java/com/lapism/searchview/SearchAdapter.java
@@ -136,6 +136,8 @@ public class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.ResultView
         } else {
             viewHolder.text.setText(item.get_text());
         }
+
+        viewHolder.id_tag = item.get_tag();
     }
 
     @Override
@@ -213,6 +215,7 @@ public class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.ResultView
 
     public class ResultViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
+        protected String id_tag;
         final ImageView icon_left;
         final TextView text;
 
@@ -226,10 +229,13 @@ public class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.ResultView
         @Override
         public void onClick(View v) {
             if (mItemClickListeners != null) {
-                for (OnItemClickListener listener : mItemClickListeners)
+                for (OnItemClickListener listener : mItemClickListeners) {
+                    v.setTag(id_tag);
                     listener.onItemClick(v, getLayoutPosition());
+                }
             }
         }
+
     }
 
 }

--- a/searchview/src/main/java/com/lapism/searchview/SearchItem.java
+++ b/searchview/src/main/java/com/lapism/searchview/SearchItem.java
@@ -17,24 +17,37 @@ public class SearchItem implements Parcelable {
             return new SearchItem[size];
         }
     };
+
+
     private int icon;
     private CharSequence text;
+    private String tag;
 
     public SearchItem() {
     }
 
     public SearchItem(CharSequence text) {
-        this(R.drawable.ic_search_black_24dp, text);
+        this(R.drawable.ic_search_black_24dp, text, null);
+    }
+
+    public SearchItem(CharSequence text, String tag) {
+        this(R.drawable.ic_search_black_24dp, text, tag);
     }
 
     public SearchItem(int icon, CharSequence text) {
+        this(icon, text, null);
+    }
+
+    public SearchItem(int icon, CharSequence text, String tag) {
         this.icon = icon;
         this.text = text;
+        this.tag = tag;
     }
 
     public SearchItem(Parcel in) {
         this.icon = in.readInt();
         this.text = in.readParcelable(CharSequence.class.getClassLoader());
+        this.tag = in.readString();
     }
 
     public int get_icon() {
@@ -53,6 +66,14 @@ public class SearchItem implements Parcelable {
         this.text = text;
     }
 
+    public String get_tag() {
+        return this.tag;
+    }
+
+    public void set_tag(String tag) {
+        this.tag = tag;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -62,6 +83,7 @@ public class SearchItem implements Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(this.icon);
         TextUtils.writeToParcel(this.text, dest, flags); // dest.writeValue(this.text);
+        dest.writeString(this.tag);
     }
 
 }


### PR DESCRIPTION
Added a String field named 'tag' to the SearchItem.
The SearchAdapter then sets this tag as the view's tag when calling the onItemClickListener. This way we can add additionnal information to the SearchItem, such as an id.