### PR TITLE
Fixed navigation icon animation setter

### DIFF
--- a/src/main/java/com/lapism/searchview/SearchView.java
+++ b/src/main/java/com/lapism/searchview/SearchView.java
@@ -745,16 +745,10 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
     }
 
     public void setNavigationIconAnimation(boolean animate) {
-        if (animate) {
-            if (mSearchArrowDrawable != null) {
-                mSearchArrowDrawable.setVerticalMirror(false);
-                mSearchArrowDrawable.animate(SearchArrowDrawable.STATE_ARROW, mAnimationDuration);
-            }
-        } else {
+        if (!animate) {
             mSearchArrowDrawable.setProgress(SearchArrowDrawable.STATE_ARROW);
         }
-
-        mArrow = true; // todo init plus !animate + anotace
+        mArrow = !animate;
     }
 
     public void setVoiceIcon(@DrawableRes int resource) {


### PR DESCRIPTION
I tested it on my device with both true and false values, and it works perfectly now. I also removed the instant arrow animation if set to true while SearchView is opened because it shouldn't animate while the arrow is already shown.