### PR TITLE
Fixed issue #293 and #302

### DIFF
--- a/src/main/java/com/lapism/searchview/SearchView.java
+++ b/src/main/java/com/lapism/searchview/SearchView.java
@@ -675,8 +675,10 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
             mFlexboxLayout.setVisibility(View.VISIBLE);
         }
 
-        if (mRecyclerViewAdapter != null && mRecyclerViewAdapter.getItemCount() > 0) {
-            mViewDivider.setVisibility(View.VISIBLE);
+        if (mRecyclerViewAdapter != null) {
+            if (mRecyclerViewAdapter.getItemCount() > 0) {
+                mViewDivider.setVisibility(View.VISIBLE);
+            }
             mRecyclerView.setVisibility(View.VISIBLE);
             SearchAnimator.fadeIn(mRecyclerView, mAnimationDuration);
         }


### PR DESCRIPTION
It appeared that `mRecyclerViewAdapter.getItemCount()` was what causing this issue. When the suggestions didn't appear, it was because `getItemCount()` returned 0. However, that still creates another minor issue that nobody noticed yet although it was there since the very old versions and that is that `mViewDivider` between the SearchView and the SearchItems won't always be shown. I think `getItemCount()` is called at the wrong time. It shouldn't be called until `setData()` in the SearchAdapter fully executes its code and initializes `mResults` so that it returns the size correctly. It doesn't return the expected size especially when the suggestions list is too huge to handle. So this is a temporary solution. I will try to think of a way to fix that when I have time. If you can also fix it then great.