### PR TITLE
Major changes, fixed issue #297

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dependencies {
 
 **Versions:**  
   
-SearchView identifies its layout style through versions. Currently, there are two values, namely `SearchView.Version.TOOLBAR` for the persistent view, and `SearchView.Version.MENU_ITEM` for the view that appears on a MenuItem press. The version can be defined through `setVersion()`.
+SearchView identifies its layout style through versions. Currently, there are two values, namely `SearchView.Version.TOOLBAR` for the persistent view, and `SearchView.Version.MENU_ITEM` for the view that appears on a MenuItem press. The version can be defined through `setVersion`.
 
 **SearchView.Version.MENU_ITEM and SearchView.Version.TOOLBAR:**
 ```java
@@ -112,9 +112,7 @@ if (mSearchView != null) {
     SearchAdapter searchAdapter = new SearchAdapter(this, suggestionsList);
     searchAdapter.setOnSearchItemClickListener(new SearchAdapter.OnSearchItemClickListener() {
         @Override
-        public void onSearchItemClick(View view, int position) {
-            TextView textView = (TextView) view.findViewById(R.id.search_text);
-            String query = textView.getText().toString();
+        public void onSearchItemClick(View view, int position, String text) {
             mHistoryDatabase.addItem(new SearchItem(text));
             mSearchView.close(false);
         }

--- a/src/main/java/com/lapism/searchview/SearchView.java
+++ b/src/main/java/com/lapism/searchview/SearchView.java
@@ -312,16 +312,23 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
     }
 
     public void setQuery(CharSequence query, boolean submit) {
-        setQueryWithoutSubmitting(query);
+        mQuery = query;
+        mSearchEditText.setText(query);
+        mSearchEditText.setSelection(mSearchEditText.length());
 
         if (!TextUtils.isEmpty(mQuery)) {
+            mImageViewClear.setVisibility(View.VISIBLE);
+            if (mVoice) {
+                mImageViewMic.setVisibility(View.GONE);
+            }
+        } else {
             mImageViewClear.setVisibility(View.GONE);
             if (mVoice) {
                 mImageViewMic.setVisibility(View.VISIBLE);
             }
         }
 
-        if (submit && !TextUtils.isEmpty(query)) {
+        if (submit) {
             onSubmitQuery();
         }
     }
@@ -651,7 +658,7 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
             SearchAnimator.fadeOut(mViewShadow, mAnimationDuration);
         }
 
-        if (!TextUtils.isEmpty(mQuery)) {
+        if (TextUtils.isEmpty(mQuery)) {
             mImageViewClear.setVisibility(View.GONE);
             if (mVoice) {
                 mImageViewMic.setVisibility(View.VISIBLE);
@@ -1154,16 +1161,6 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
         }
     }
 
-    private void setQueryWithoutSubmitting(CharSequence query) {
-        mSearchEditText.setText(query);
-        if (query != null) {
-            mSearchEditText.setSelection(mSearchEditText.length());
-            mQuery = query;
-        } else {
-            mSearchEditText.getText().clear();
-        }
-    }
-
     private void onSubmitQuery() {
         CharSequence query = mSearchEditText.getText();
         if (query != null && TextUtils.getTrimmedLength(query) > 0) {
@@ -1242,7 +1239,7 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
         SavedState ss = (SavedState) state;
         if (ss.isSearchOpen) {
             open(true);
-            setQueryWithoutSubmitting(ss.query);
+            setQuery(ss.query, false);
             mSearchEditText.requestFocus();
         }
 

--- a/src/main/java/com/lapism/searchview/SearchView.java
+++ b/src/main/java/com/lapism/searchview/SearchView.java
@@ -59,6 +59,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 // @RestrictTo(LIBRARY_GROUP)
 // @CoordinatorLayout.DefaultBehavior(SearchBehavior.class)
@@ -847,6 +848,10 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
         mAnimationDuration = animationDuration;
     }
 
+    public void setSearchItemAnimator(RecyclerView.ItemAnimator itemAnimator) {
+        mRecyclerView.setItemAnimator(itemAnimator);
+    }
+
     // ---------------------------------------------------------------------------------------------
     private void initView() {
         LayoutInflater.from(mContext).inflate((R.layout.search_view), this, true);
@@ -1089,23 +1094,26 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
         }
 
         if (mRecyclerViewAdapter != null && mRecyclerViewAdapter instanceof Filterable) {
+            final CharSequence mFilterKey = newText.toString().toLowerCase(Locale.getDefault());
             ((SearchAdapter) mRecyclerViewAdapter).getFilter().filter(newText, new Filter.FilterListener() {
                 @Override
                 public void onFilterComplete(int i) {
-                    if (mShouldShowProgress) {
-                        hideProgress();
-                    }
-                    if (i > 0) {
-                        if (mRecyclerView.getVisibility() == View.GONE) {
-                            mViewDivider.setVisibility(View.VISIBLE);
-                            mRecyclerView.setVisibility(View.VISIBLE);
-                            SearchAnimator.fadeIn(mRecyclerView, mAnimationDuration);
+                    if (mFilterKey.equals(((SearchAdapter) mRecyclerViewAdapter).getKey())) {
+                        if (mShouldShowProgress) {
+                            hideProgress();
                         }
-                    } else {
-                        if (mRecyclerView.getVisibility() == View.VISIBLE) {
-                            mViewDivider.setVisibility(View.GONE);
-                            mRecyclerView.setVisibility(View.GONE);
-                            SearchAnimator.fadeOut(mRecyclerView, mAnimationDuration);
+                        if (i > 0) {
+                            if (mRecyclerView.getVisibility() == View.GONE) {
+                                mViewDivider.setVisibility(View.VISIBLE);
+                                mRecyclerView.setVisibility(View.VISIBLE);
+                                SearchAnimator.fadeIn(mRecyclerView, mAnimationDuration);
+                            }
+                        } else {
+                            if (mRecyclerView.getVisibility() == View.VISIBLE) {
+                                mViewDivider.setVisibility(View.GONE);
+                                mRecyclerView.setVisibility(View.GONE);
+                                SearchAnimator.fadeOut(mRecyclerView, mAnimationDuration);
+                            }
                         }
                     }
                 }

--- a/src/main/java/com/lapism/searchview/SearchView.java
+++ b/src/main/java/com/lapism/searchview/SearchView.java
@@ -775,13 +775,19 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
 
     public void setVoiceIcon(@DrawableRes int resource) {
         mImageViewMic.setImageResource(resource);
+        if (resource == 0) {
+            mImageViewMic.setVisibility(View.GONE);
+        } else {
+            mImageViewMic.setVisibility(View.VISIBLE);
+        }
     }
 
     public void setVoiceIcon(@Nullable Drawable drawable) {
+        mImageViewMic.setImageDrawable(drawable);
         if (drawable == null) {
             mImageViewMic.setVisibility(View.GONE);
         } else {
-            mImageViewMic.setImageDrawable(drawable);
+            mImageViewMic.setVisibility(View.VISIBLE);
         }
     }
 

--- a/src/main/java/com/lapism/searchview/SearchView.java
+++ b/src/main/java/com/lapism/searchview/SearchView.java
@@ -738,13 +738,23 @@ public class SearchView extends FrameLayout implements View.OnClickListener {
 
     public void setNavigationIcon(@DrawableRes int resource) {
         mImageViewArrow.setImageResource(resource);
+        if (resource == 0) {
+            mImageViewArrow.setVisibility(View.GONE);
+            mSearchEditText.setPadding((int) getResources().getDimension(R.dimen.search_key_line_16), 0, 0, 0);
+        } else {
+            mImageViewArrow.setVisibility(View.VISIBLE);
+            mSearchEditText.setPadding(0, 0, 0, 0);
+        }
     }
 
     public void setNavigationIcon(@Nullable Drawable drawable) {
+        mImageViewArrow.setImageDrawable(drawable);
         if (drawable == null) {
             mImageViewArrow.setVisibility(View.GONE);
+            mSearchEditText.setPadding((int) getResources().getDimension(R.dimen.search_key_line_16), 0, 0, 0);
         } else {
-            mImageViewArrow.setImageDrawable(drawable);
+            mImageViewArrow.setVisibility(View.VISIBLE);
+            mSearchEditText.setPadding(0, 0, 0, 0);
         }
     }
 

--- a/src/main/res/layout/search_item.xml
+++ b/src/main/res/layout/search_item.xml
@@ -19,15 +19,14 @@
         android:id="@+id/search_text"
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_gravity="start|center_vertical"
         android:layout_weight="1"
         android:ellipsize="end"
         android:gravity="start|center_vertical"
         android:maxLines="1"
         android:paddingEnd="@dimen/search_key_line_16"
-        android:paddingLeft="@dimen/search_key_line_8"
+        android:paddingLeft="0dp"
         android:paddingRight="@dimen/search_key_line_16"
-        android:paddingStart="@dimen/search_key_line_8"
+        android:paddingStart="0dp"
         android:textIsSelectable="false"
         android:textSize="@dimen/search_text_small" />
 

--- a/src/main/res/layout/search_view.xml
+++ b/src/main/res/layout/search_view.xml
@@ -42,7 +42,6 @@
                     android:id="@+id/search_searchEditText"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
-                    android:layout_gravity="start|center_vertical"
                     android:layout_weight="1"
                     android:background="@android:color/transparent"
                     android:ellipsize="end"
@@ -51,10 +50,6 @@
                     android:imeOptions="actionSearch|flagNoExtractUi"
                     android:inputType="textNoSuggestions"
                     android:maxLines="1"
-                    android:paddingEnd="@dimen/search_key_line_16"
-                    android:paddingLeft="@dimen/search_key_line_8"
-                    android:paddingRight="@dimen/search_key_line_16"
-                    android:paddingStart="@dimen/search_key_line_8"
                     android:privateImeOptions="nm"
                     android:textSize="@dimen/search_text_medium"
                     android:windowSoftInputMode="stateAlwaysHidden" />
@@ -63,7 +58,11 @@
                     android:id="@+id/search_progressBar"
                     style="?android:attr/indeterminateProgressStyle"
                     android:layout_width="@dimen/search_progress"
-                    android:layout_height="match_parent" />
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="0dp"
+                    android:layout_marginLeft="@dimen/search_key_line_16"
+                    android:layout_marginRight="0dp"
+                    android:layout_marginStart="@dimen/search_key_line_16" />
 
                 <FrameLayout
                     android:layout_width="48dp"


### PR DESCRIPTION
1. It turned out that the reason of getting incorrect results sometimes (for example when `SearchEditText` is empty and some results are still shown) was because a new instance of `Filter` was created every time `getFilter().filter()` is called. This caused unordered publication of results. Reading this [Stack Overflow question](https://stackoverflow.com/questions/19159730/filtering-in-array-list-filterable-not-cancelling-the-previous-filter) and [Android Documentation of Filter](https://developer.android.com/reference/android/widget/Filter.html), any call to `getFilter().filter()` where `getFilter()` returns the same `Filter` instance will cancel any previous non-executed filtering request. Implementing this fixed issue #297, but another issue got created causing the whole filter cycle be slower as when a `Filter` already executes its filter request, it can't be cancelled and the next filter request won't be executed until the former filter request is finished executing. So I fixed this issue through another way by reverting the changes, creating a new filter request every time `getFilter().filter()` is called and checking whether the filter query `mFilterKey` is equal to the current query `mKey` or not. If it's equal, then `publishResults()` else do nothing.

2. Added `setSearchItemAnimator()` to `SearchView`. This method will change `mRecyclerView`'s `ItemAnimator`. Passing `null` will remove the animation.

3. Improved navigation/voice icon setter, fixed navigation/voice icon visibility change from `GONE` to `VISIBLE` when drawable is available, added left padding to `SearchEditText` when navigation icon is `GONE`.

4. Improved `SearchView` and `SearchItem` dimensions to be more accurate and let their child views be equally spaced.

5. Added ability to get `SearchItem` text within `onSearchItemClick()`.

6. Changed `getResultList()` to `getResultsList()` in `SearchAdapter`.

7. Fixed `setQuery()` visibility changes, removed `setQueryWithoutSubmitting()` as it was useless and implemented it directly in `setQuery()`.

8. Fixed `removeFocus()` visibility changes.